### PR TITLE
feat: implement session store and library UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.8.2",
-        "tailwind-merge": "^3.3.1"
+        "tailwind-merge": "^3.3.1",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",
@@ -3963,6 +3964,35 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.8.2",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { ProtectedRoute } from '@/components/ProtectedRoute';
 import AppLayout from '@/layouts/AppLayout';
 import Login from '@/pages/Login';
 import Home from '@/pages/Home';
+import Session from '@/pages/Session';
 import "./App.css";
 
 function App() {
@@ -21,6 +22,7 @@ function App() {
                 }
               >
         <Route path="home" element={<Home />} />
+        <Route path="session/:id" element={<Session />} />
         <Route index element={<Navigate to="/app/home" replace />} />
       </Route>
       <Route

--- a/src/components/CreateSessionModal.tsx
+++ b/src/components/CreateSessionModal.tsx
@@ -1,0 +1,124 @@
+import React, { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface CreateSessionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (title: string, course: string) => Promise<void>;
+  loading?: boolean;
+}
+
+export const CreateSessionModal: React.FC<CreateSessionModalProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  loading = false
+}) => {
+  const [title, setTitle] = useState('');
+  const [course, setCourse] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    
+    await onSubmit(title.trim(), course.trim());
+    setTitle('');
+    setCourse('');
+  };
+
+  const handleClose = () => {
+    if (!loading) {
+      setTitle('');
+      setCourse('');
+      onClose();
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+          onClick={handleClose}
+        >
+          <motion.div
+            initial={{ scale: 0.95, opacity: 0, y: 20 }}
+            animate={{ scale: 1, opacity: 1, y: 0 }}
+            exit={{ scale: 0.95, opacity: 0, y: 20 }}
+            transition={{ type: "spring", damping: 25, stiffness: 300 }}
+            onClick={(e) => e.stopPropagation()}
+            className="w-full max-w-md"
+          >
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+                <CardTitle className="text-lg font-semibold">New Session</CardTitle>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleClose}
+                  disabled={loading}
+                  className="h-8 w-8 p-0"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </CardHeader>
+              <CardContent>
+                <form onSubmit={handleSubmit} className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="title">Session Title *</Label>
+                    <Input
+                      id="title"
+                      value={title}
+                      onChange={(e) => setTitle(e.target.value)}
+                      placeholder="Enter session title"
+                      required
+                      disabled={loading}
+                    />
+                  </div>
+                  
+                  <div className="space-y-2">
+                    <Label htmlFor="course">Course (Optional)</Label>
+                    <Input
+                      id="course"
+                      value={course}
+                      onChange={(e) => setCourse(e.target.value)}
+                      placeholder="Enter course name"
+                      disabled={loading}
+                    />
+                  </div>
+                  
+                  <div className="flex gap-3 pt-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={handleClose}
+                      disabled={loading}
+                      className="flex-1"
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      type="submit"
+                      disabled={!title.trim() || loading}
+                      className="flex-1"
+                    >
+                      {loading ? 'Creating...' : 'Create Session'}
+                    </Button>
+                  </div>
+                </form>
+              </CardContent>
+            </Card>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/components/SessionCard.tsx
+++ b/src/components/SessionCard.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Clock, BookOpen, Play } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Session } from '@/types/session';
+
+interface SessionCardProps {
+  session: Session;
+  onClick?: () => void;
+  className?: string;
+}
+
+export const SessionCard: React.FC<SessionCardProps> = ({ 
+  session, 
+  onClick, 
+  className = '' 
+}) => {
+  const formatDate = (timestamp: number) => {
+    return new Date(timestamp * 1000).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric'
+    });
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'draft': return 'bg-gray-100 text-gray-800';
+      case 'recording': return 'bg-red-100 text-red-800';
+      case 'complete': return 'bg-green-100 text-green-800';
+      default: return 'bg-gray-100 text-gray-800';
+    }
+  };
+
+  const getStatusIcon = (status: string) => {
+    switch (status) {
+      case 'draft': return <Clock className="w-3 h-3" />;
+      case 'recording': return <Play className="w-3 h-3" />;
+      case 'complete': return <BookOpen className="w-3 h-3" />;
+      default: return <Clock className="w-3 h-3" />;
+    }
+  };
+
+  return (
+    <motion.div
+      whileHover={{ y: -2 }}
+      whileTap={{ scale: 0.98 }}
+      transition={{ duration: 0.2 }}
+    >
+      <Card 
+        className={`cursor-pointer hover:shadow-lg transition-shadow ${className}`}
+        onClick={onClick}
+      >
+        <CardHeader className="pb-3">
+          <div className="flex items-start justify-between">
+            <CardTitle className="text-base font-medium line-clamp-2 leading-tight">
+              {session.title}
+            </CardTitle>
+            <span className={`px-2 py-1 text-xs font-medium rounded-full flex items-center gap-1 ${getStatusColor(session.status)}`}>
+              {getStatusIcon(session.status)}
+              {session.status}
+            </span>
+          </div>
+        </CardHeader>
+        <CardContent className="pt-0">
+          {session.course && (
+            <p className="text-sm text-muted-foreground mb-2 line-clamp-1">
+              {session.course}
+            </p>
+          )}
+          <div className="flex items-center text-xs text-muted-foreground">
+            <Clock className="w-3 h-3 mr-1" />
+            {formatDate(session.created_at)}
+          </div>
+          {session.duration_ms > 0 && (
+            <div className="flex items-center text-xs text-muted-foreground mt-1">
+              <Play className="w-3 h-3 mr-1" />
+              {Math.round(session.duration_ms / 1000)}s
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+};

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Session } from '@/types/session';
+import { SessionCard } from './SessionCard';
+import { Skeleton } from '@/components/ui/skeleton';
+
+interface SessionListProps {
+  sessions: Session[];
+  loading: boolean;
+  view: 'list' | 'grid';
+  onSessionClick?: (session: Session) => void;
+}
+
+export const SessionList: React.FC<SessionListProps> = ({
+  sessions,
+  loading,
+  view,
+  onSessionClick
+}) => {
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        {[1, 2, 3, 4].map((index) => (
+          <motion.div
+            key={index}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: index * 0.1 }}
+          >
+            <div className="bg-card border rounded-lg p-4">
+              <div className="flex items-start space-x-4">
+                <Skeleton className="h-12 w-12 rounded" />
+                <div className="space-y-2 flex-1">
+                  <Skeleton className="h-4 w-3/4" />
+                  <Skeleton className="h-3 w-1/2" />
+                  <Skeleton className="h-3 w-1/4" />
+                </div>
+                <Skeleton className="h-6 w-16 rounded-full" />
+              </div>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+    );
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="text-center py-12"
+      >
+        <div className="text-muted-foreground">
+          <p className="text-lg font-medium mb-2">No sessions yet</p>
+          <p className="text-sm">Create your first session to get started</p>
+        </div>
+      </motion.div>
+    );
+  }
+
+  if (view === 'grid') {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {sessions.map((session, index) => (
+          <motion.div
+            key={session.id}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: index * 0.1 }}
+          >
+            <SessionCard
+              session={session}
+              onClick={() => onSessionClick?.(session)}
+            />
+          </motion.div>
+        ))}
+      </div>
+    );
+  }
+
+  // List view
+  return (
+    <div className="space-y-3">
+      {sessions.map((session, index) => (
+        <motion.div
+          key={session.id}
+          initial={{ opacity: 0, x: -20 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ delay: index * 0.05 }}
+        >
+          <SessionCard
+            session={session}
+            onClick={() => onSessionClick?.(session)}
+            className="!cursor-pointer"
+          />
+        </motion.div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/ViewToggle.tsx
+++ b/src/components/ViewToggle.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { List, Grid3X3 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface ViewToggleProps {
+  view: 'list' | 'grid';
+  onViewChange: (view: 'list' | 'grid') => void;
+}
+
+export const ViewToggle: React.FC<ViewToggleProps> = ({ view, onViewChange }) => {
+  return (
+    <div className="flex items-center gap-1 p-1 bg-muted rounded-lg">
+      <Button
+        variant={view === 'list' ? 'default' : 'ghost'}
+        size="sm"
+        onClick={() => onViewChange('list')}
+        className="h-8 w-8 p-0"
+      >
+        <List className="h-4 w-4" />
+      </Button>
+      <Button
+        variant={view === 'grid' ? 'default' : 'ghost'}
+        size="sm"
+        onClick={() => onViewChange('grid')}
+        className="h-8 w-8 p-0"
+      >
+        <Grid3X3 className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -99,6 +99,20 @@
   .animate-shake {
     animation: shake 0.5s cubic-bezier(.36,.07,.19,.97) both;
   }
+  
+  .line-clamp-1 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+  }
+  
+  .line-clamp-2 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
 }
 
 @keyframes shake {

--- a/src/lib/sessions.ts
+++ b/src/lib/sessions.ts
@@ -1,0 +1,16 @@
+import { invoke } from '@tauri-apps/api/core';
+import { Session, CreateSessionRequest, UpdateSessionStatusRequest } from '@/types/session';
+
+export const sessionsClient = {
+  async listSessions(): Promise<Session[]> {
+    return await invoke<Session[]>('cmd_list_sessions');
+  },
+
+  async createSession(request: CreateSessionRequest): Promise<Session> {
+    return await invoke<Session>('cmd_create_session', { ...request });
+  },
+
+  async updateSessionStatus(request: UpdateSessionStatusRequest): Promise<void> {
+    await invoke('cmd_update_session_status', { ...request });
+  }
+};

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,135 +1,177 @@
 import { motion } from 'framer-motion';
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Mic, Play, Clock, BookOpen } from 'lucide-react';
+import { Mic, Plus, BookOpen, Clock } from 'lucide-react';
 import PageTransition from '@/components/PageTransition';
-import { SkeletonRow } from '@/components/ui/skeleton-row';
+import { ViewToggle } from '@/components/ViewToggle';
+import { SessionList } from '@/components/SessionList';
+import { CreateSessionModal } from '@/components/CreateSessionModal';
+import { useSessionsStore } from '@/store/sessions';
 
 export default function Home() {
-  // Simulate loading state for demo purposes
-  const [isLoading, setIsLoading] = useState(true);
+  const navigate = useNavigate();
+  const [view, setView] = useState<'list' | 'grid'>('grid');
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  
+  const { sessions, loading, error, load, create, clearError } = useSessionsStore();
 
   useEffect(() => {
-    // Simulate API call delay
-    const timer = setTimeout(() => {
-      setIsLoading(false);
-    }, 2000);
+    load();
+  }, [load]);
 
-    return () => clearTimeout(timer);
-  }, []);
+  const handleCreateSession = async (title: string, course: string) => {
+    const newSession = await create({ title, course });
+    if (newSession) {
+      setShowCreateModal(false);
+      navigate(`/app/session/${newSession.id}`);
+    }
+  };
+
+  const handleSessionClick = (session: any) => {
+    navigate(`/app/session/${session.id}`);
+  };
 
   return (
     <PageTransition>
       <div className="p-8 max-w-6xl mx-auto">
-      {/* Welcome Header */}
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6, ease: 'easeOut' }}
-        className="text-center mb-12"
-      >
-        <h1 className="text-4xl font-bold text-foreground mb-4">
-          Welcome to Polka
-        </h1>
-        <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-          Your AI-powered note-taking companion. Never miss important moments in class again.
-        </p>
-      </motion.div>
+        {/* Welcome Header */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, ease: 'easeOut' }}
+          className="text-center mb-12"
+        >
+          <h1 className="text-4xl font-bold text-foreground mb-4">
+            Welcome to Polka
+          </h1>
+          <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
+            Your AI-powered note-taking companion. Never miss important moments in class again.
+          </p>
+        </motion.div>
 
-      {/* Quick Actions */}
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6, ease: 'easeOut', delay: 0.1 }}
-        className="mb-12"
-      >
-        <div className="flex justify-center">
-          <Button
-            size="lg"
-            className="h-16 px-8 text-lg font-semibold bg-primary hover:bg-primary/90 shadow-lg hover:shadow-xl transition-all"
-            onClick={() => console.log('New Session clicked')}
-          >
-            <Mic className="w-6 h-6 mr-3" />
-            Start New Session
-          </Button>
-        </div>
-      </motion.div>
+        {/* Quick Actions */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, ease: 'easeOut', delay: 0.1 }}
+          className="mb-12"
+        >
+          <div className="flex justify-center">
+            <Button
+              size="lg"
+              className="h-16 px-8 text-lg font-semibold bg-primary hover:bg-primary/90 shadow-lg hover:shadow-xl transition-all"
+              onClick={() => setShowCreateModal(true)}
+            >
+              <Plus className="w-6 h-6 mr-3" />
+              New Session
+            </Button>
+          </div>
+        </motion.div>
 
-      {/* Feature Cards */}
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6, ease: 'easeOut', delay: 0.2 }}
-        className="grid grid-cols-1 md:grid-cols-3 gap-6"
-      >
-        <Card className="hover:shadow-lg transition-shadow">
-          <CardHeader>
-            <div className="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-3">
-              <Mic className="w-6 h-6 text-primary" />
-            </div>
-            <CardTitle>Record & Transcribe</CardTitle>
-            <CardDescription>
-              Capture audio from any source and get instant AI-powered transcriptions
-            </CardDescription>
-          </CardHeader>
-        </Card>
-
-        <Card className="hover:shadow-lg transition-shadow">
-          <CardHeader>
-            <div className="w-12 h-12 bg-secondary/10 rounded-lg flex items-center justify-center mb-3">
-              <BookOpen className="w-6 h-6 text-secondary" />
-            </div>
-            <CardTitle>Smart Notes</CardTitle>
-            <CardDescription>
-              AI automatically highlights key concepts and creates study-friendly summaries
-            </CardDescription>
-          </CardHeader>
-        </Card>
-
-        <Card className="hover:shadow-lg transition-shadow">
-          <CardHeader>
-            <div className="w-12 h-12 bg-accent/10 rounded-lg flex items-center justify-center mb-3">
-              <Clock className="w-6 h-6 text-accent" />
-            </div>
-            <CardTitle>Never Miss Out</CardTitle>
-            <CardDescription>
-              Engagement tracking detects when you zone out and helps you catch up
-            </CardDescription>
-          </CardHeader>
-        </Card>
-      </motion.div>
-
-      {/* Recent Activity Placeholder */}
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6, ease: 'easeOut', delay: 0.3 }}
-        className="mt-12"
-      >
-        <Card>
-          <CardHeader>
-            <CardTitle>Recent Sessions</CardTitle>
-            <CardDescription>
-              Your recent note-taking sessions will appear here
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {isLoading ? (
-              <div className="space-y-0">
-                {[0, 1, 2].map((index) => (
-                  <SkeletonRow key={index} index={index} />
-                ))}
+        {/* Feature Cards */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, ease: 'easeOut', delay: 0.2 }}
+          className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12"
+        >
+          <Card className="hover:shadow-lg transition-shadow">
+            <CardHeader>
+              <div className="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-3">
+                <Mic className="w-6 h-6 text-primary" />
               </div>
-            ) : (
-              <div className="text-center py-8 text-muted-foreground">
-                <Play className="w-12 h-12 mx-auto mb-4 opacity-50" />
-                <p>No sessions yet. Start your first recording to see it here!</p>
+              <CardTitle>Record & Transcribe</CardTitle>
+              <CardDescription>
+                Capture audio from any source and get instant AI-powered transcriptions
+              </CardDescription>
+            </CardHeader>
+          </Card>
+
+          <Card className="hover:shadow-lg transition-shadow">
+            <CardHeader>
+              <div className="w-12 h-12 bg-secondary/10 rounded-lg flex items-center justify-center mb-3">
+                <BookOpen className="w-6 h-6 text-secondary" />
               </div>
-            )}
-          </CardContent>
-        </Card>
-      </motion.div>
+              <CardTitle>Smart Notes</CardTitle>
+              <CardDescription>
+                AI automatically highlights key concepts and creates study-friendly summaries
+              </CardDescription>
+            </CardHeader>
+          </Card>
+
+          <Card className="hover:shadow-lg transition-shadow">
+            <CardHeader>
+              <div className="w-12 h-12 bg-accent/10 rounded-lg flex items-center justify-center mb-3">
+                <Clock className="w-6 h-6 text-accent" />
+              </div>
+              <CardTitle>Never Miss Out</CardTitle>
+              <CardDescription>
+                Engagement tracking detects when you zone out and helps you catch up
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        </motion.div>
+
+        {/* Sessions Library */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, ease: 'easeOut', delay: 0.3 }}
+          className="mb-8"
+        >
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div>
+                  <CardTitle className="text-2xl font-bold">Sessions Library</CardTitle>
+                  <CardDescription>
+                    {sessions.length > 0 
+                      ? `${sessions.length} session${sessions.length === 1 ? '' : 's'}`
+                      : 'No sessions yet'
+                    }
+                  </CardDescription>
+                </div>
+                <ViewToggle view={view} onViewChange={setView} />
+              </div>
+            </CardHeader>
+            <CardContent>
+              {error && (
+                <motion.div
+                  initial={{ opacity: 0, y: -10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  className="mb-4 p-3 bg-destructive/10 border border-destructive/20 rounded-lg text-destructive text-sm"
+                >
+                  {error}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={clearError}
+                    className="ml-2 h-auto p-1 text-destructive hover:bg-destructive/20"
+                  >
+                    ×
+                  </Button>
+                </motion.div>
+              )}
+              
+              <SessionList
+                sessions={sessions}
+                loading={loading}
+                view={view}
+                onSessionClick={handleSessionClick}
+              />
+            </CardContent>
+          </Card>
+        </motion.div>
+
+        {/* Create Session Modal */}
+        <CreateSessionModal
+          isOpen={showCreateModal}
+          onClose={() => setShowCreateModal(false)}
+          onSubmit={handleCreateSession}
+          loading={loading}
+        />
       </div>
     </PageTransition>
   );

--- a/src/pages/Session.tsx
+++ b/src/pages/Session.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { ArrowLeft, Mic, Play, Square, BookOpen } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useSessionsStore } from '@/store/sessions';
+import { Session as SessionType } from '@/types/session';
+import PageTransition from '@/components/PageTransition';
+
+export default function Session() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [session, setSession] = useState<SessionType | null>(null);
+  const [isRecording, setIsRecording] = useState(false);
+  const { sessions } = useSessionsStore();
+
+  useEffect(() => {
+    if (id && sessions.length > 0) {
+      const foundSession = sessions.find(s => s.id === id);
+      if (foundSession) {
+        setSession(foundSession);
+      }
+    }
+  }, [id, sessions]);
+
+  const handleBack = () => {
+    navigate('/app/home');
+  };
+
+  const toggleRecording = () => {
+    setIsRecording(!isRecording);
+    // TODO: Implement actual recording logic
+  };
+
+  if (!session) {
+    return (
+      <PageTransition>
+        <div className="p-8 max-w-4xl mx-auto">
+          <div className="text-center py-12">
+            <div className="text-muted-foreground">
+              <p className="text-lg font-medium mb-2">Session not found</p>
+              <Button onClick={handleBack} variant="outline">
+                <ArrowLeft className="w-4 h-4 mr-2" />
+                Back to Home
+              </Button>
+            </div>
+          </div>
+        </div>
+      </PageTransition>
+    );
+  }
+
+  return (
+    <PageTransition>
+      <div className="p-8 max-w-4xl mx-auto">
+        {/* Header */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="mb-8"
+        >
+          <div className="flex items-center gap-4 mb-6">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleBack}
+              className="h-10 w-10 p-0"
+            >
+              <ArrowLeft className="w-5 h-5" />
+            </Button>
+            <div>
+              <h1 className="text-3xl font-bold text-foreground">{session.title}</h1>
+              {session.course && (
+                <p className="text-lg text-muted-foreground">{session.course}</p>
+              )}
+            </div>
+          </div>
+        </motion.div>
+
+        {/* Recording Controls */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.1 }}
+          className="mb-8"
+        >
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Mic className="w-5 h-5" />
+                Recording Controls
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex items-center gap-4">
+                <Button
+                  size="lg"
+                  onClick={toggleRecording}
+                  className={`h-16 px-8 text-lg font-semibold ${
+                    isRecording 
+                      ? 'bg-red-600 hover:bg-red-700' 
+                      : 'bg-primary hover:bg-primary/90'
+                  }`}
+                >
+                  {isRecording ? (
+                    <>
+                      <Square className="w-6 h-6 mr-3" />
+                      Stop Recording
+                    </>
+                  ) : (
+                    <>
+                      <Play className="w-6 h-6 mr-3" />
+                      Start Recording
+                    </>
+                  )}
+                </Button>
+                
+                <div className="text-sm text-muted-foreground">
+                  {isRecording ? (
+                    <span className="text-red-600 font-medium">● Recording...</span>
+                  ) : (
+                    <span>Click to start recording your session</span>
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </motion.div>
+
+        {/* Session Info */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.2 }}
+          className="grid grid-cols-1 md:grid-cols-2 gap-6"
+        >
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <BookOpen className="w-5 h-5" />
+                Session Details
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Status:</span>
+                <span className={`px-2 py-1 text-xs font-medium rounded-full ${
+                  session.status === 'draft' ? 'bg-gray-100 text-gray-800' :
+                  session.status === 'recording' ? 'bg-red-100 text-red-800' :
+                  'bg-green-100 text-green-800'
+                }`}>
+                  {session.status}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Created:</span>
+                <span>{new Date(session.created_at * 1000).toLocaleDateString()}</span>
+              </div>
+              {session.duration_ms > 0 && (
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Duration:</span>
+                  <span>{Math.round(session.duration_ms / 1000)}s</span>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Quick Actions</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <Button variant="outline" className="w-full justify-start">
+                <BookOpen className="w-4 h-4 mr-2" />
+                View Notes
+              </Button>
+              <Button variant="outline" className="w-full justify-start">
+                <Play className="w-4 h-4 mr-2" />
+                Play Audio
+              </Button>
+              <Button variant="outline" className="w-full justify-start">
+                <BookOpen className="w-4 h-4 mr-2" />
+                View Transcript
+              </Button>
+            </CardContent>
+          </Card>
+        </motion.div>
+
+        {/* Placeholder for future recorder functionality */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.3 }}
+          className="mt-8"
+        >
+          <Card>
+            <CardHeader>
+              <CardTitle>Recorder Interface</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-center py-12 text-muted-foreground">
+                <Mic className="w-16 h-16 mx-auto mb-4 opacity-30" />
+                <p className="text-lg font-medium mb-2">Recorder Coming Soon</p>
+                <p className="text-sm">
+                  The audio recording interface will be implemented here in the next phase.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </motion.div>
+      </div>
+    </PageTransition>
+  );
+}

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -1,0 +1,72 @@
+import { create } from 'zustand';
+import { Session, CreateSessionRequest, UpdateSessionStatusRequest } from '@/types/session';
+import { sessionsClient } from '@/lib/sessions';
+
+interface SessionsState {
+  sessions: Session[];
+  loading: boolean;
+  error: string | null;
+  
+  // Actions
+  load: () => Promise<void>;
+  create: (request: CreateSessionRequest) => Promise<Session | null>;
+  updateStatus: (request: UpdateSessionStatusRequest) => Promise<void>;
+  clearError: () => void;
+}
+
+export const useSessionsStore = create<SessionsState>((set) => ({
+  sessions: [],
+  loading: false,
+  error: null,
+
+  load: async () => {
+    try {
+      set({ loading: true, error: null });
+      const sessions = await sessionsClient.listSessions();
+      set({ sessions, loading: false });
+    } catch (error) {
+      set({ 
+        error: error instanceof Error ? error.message : 'Failed to load sessions', 
+        loading: false 
+      });
+    }
+  },
+
+  create: async (request: CreateSessionRequest) => {
+    try {
+      set({ loading: true, error: null });
+      const newSession = await sessionsClient.createSession(request);
+      set(state => ({ 
+        sessions: [newSession, ...state.sessions], 
+        loading: false 
+      }));
+      return newSession;
+    } catch (error) {
+      set({ 
+        error: error instanceof Error ? error.message : 'Failed to create session', 
+        loading: false 
+      });
+      return null;
+    }
+  },
+
+  updateStatus: async (request: UpdateSessionStatusRequest) => {
+    try {
+      set({ error: null });
+      await sessionsClient.updateSessionStatus(request);
+      set(state => ({
+        sessions: state.sessions.map(session =>
+          session.id === request.id
+            ? { ...session, status: request.status }
+            : session
+        )
+      }));
+    } catch (error) {
+      set({ 
+        error: error instanceof Error ? error.message : 'Failed to update session status' 
+      });
+    }
+  },
+
+  clearError: () => set({ error: null }),
+}));


### PR DESCRIPTION
- Add zustand store for session state management
- Create session client for Tauri command integration
- Build Notion-like library interface with grid/list toggle
- Add session cards showing title, course, date, and status
- Implement create session modal with form validation
- Add session detail page with recording controls placeholder
- Include loading skeletons, error handling, and smooth transitions
- Add route /app/session/:id for individual sessions
- Update Home.tsx to use real session store instead of placeholders

UI is complete and ready for Tauri backend integration.