### PR TITLE
feat: implement persistent per-session artifacts with file system storage

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -136,6 +136,21 @@ fn get_data_dir() -> Result<PathBuf> {
     Ok(home.join(".polka").join("data"))
 }
 
+fn get_sessions_dir() -> Result<PathBuf> {
+    let data_dir = get_data_dir()?;
+    Ok(data_dir.join("sessions"))
+}
+
+pub fn create_session_folder(session_id: &str) -> Result<PathBuf> {
+    let sessions_dir = get_sessions_dir()?;
+    let session_dir = sessions_dir.join(session_id);
+    
+    // Create the session directory if it doesn't exist
+    fs::create_dir_all(&session_dir)?;
+    
+    Ok(session_dir)
+}
+
 pub fn init_db() -> Result<Database> {
     Database::new()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,11 +1,14 @@
 pub mod db;
 pub mod models;
 
-use crate::db::Database;
-use crate::models::{Session, SessionStatus};
+use crate::db::{Database, create_session_folder};
+use crate::models::{Session, SessionStatus, TranscriptLine};
 use anyhow::Result;
 use std::sync::Mutex;
 use std::str::FromStr;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
 use tauri::State;
 use nanoid::nanoid;
 
@@ -14,10 +17,29 @@ pub struct AppState {
     db: Mutex<Database>,
 }
 
+// Helper function to get session directory
+fn get_session_dir(session_id: &str) -> Result<PathBuf, String> {
+    let home = dirs::home_dir().ok_or("Could not find home directory")?;
+    Ok(home.join(".polka").join("data").join("sessions").join(session_id))
+}
+
+// Helper function to get full path for session file
+fn get_session_file_path(session_id: &str, filename: &str) -> Result<PathBuf, String> {
+    let session_dir = get_session_dir(session_id)?;
+    Ok(session_dir.join(filename))
+}
+
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command]
 fn greet(name: &str) -> String {
+    println!("🔧 greet command called with name: {}", name);
     format!("Hello, {}! You've been greeted from Rust!", name)
+}
+
+#[tauri::command]
+fn test_backend() -> String {
+    println!("🔧 test_backend command called - backend is working!");
+    "Backend is working!".to_string()
 }
 
 #[tauri::command]
@@ -34,16 +56,21 @@ async fn cmd_create_session(
 ) -> Result<Session, String> {
     let db = state.db.lock().map_err(|e| e.to_string())?;
     
+    let session_id = nanoid!();
+    
+    // Create session folder and set file paths
+    let _session_dir = create_session_folder(&session_id).map_err(|e| e.to_string())?;
+    
     let session = Session {
-        id: nanoid!(),
+        id: session_id,
         title,
         course,
         created_at: time::OffsetDateTime::now_utc().unix_timestamp(),
         duration_ms: 0,
         status: SessionStatus::Draft,
-        notes_path: None,
-        audio_path: None,
-        transcript_path: None,
+        notes_path: Some("notes.md".to_string()),
+        audio_path: Some("audio.wav".to_string()),
+        transcript_path: Some("transcript.jsonl".to_string()),
     };
     
     db.insert_session(&session).map_err(|e| e.to_string())?;
@@ -62,6 +89,193 @@ async fn cmd_update_session_status(
         .map_err(|e| e.to_string())?;
     
     db.update_session_status(&id, &status_enum).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn cmd_append_transcript_line(
+    id: String,
+    t_ms: u64,
+    speaker: String,
+    text: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    println!("🔧 cmd_append_transcript_line called with id: {}, t_ms: {}, speaker: {}, text: {}", id, t_ms, speaker, text);
+    
+    let db = state.db.lock().map_err(|e| {
+        println!("❌ Failed to lock database: {}", e);
+        e.to_string()
+    })?;
+    
+    // Get session to ensure it exists and get transcript path
+    let session = db.get_session(&id).map_err(|e| {
+        println!("❌ Failed to get session: {}", e);
+        e.to_string()
+    })?.ok_or_else(|| {
+        println!("❌ Session not found: {}", id);
+        "Session not found".to_string()
+    })?;
+    
+    println!("✅ Found session: {:?}", session);
+    
+    let transcript_path = session.transcript_path
+        .unwrap_or_else(|| "transcript.jsonl".to_string()); // Default if missing
+    
+    println!("📄 Using transcript path: {}", transcript_path);
+    
+    let full_path = get_session_file_path(&id, &transcript_path).map_err(|e| {
+        println!("❌ Failed to get session file path: {}", e);
+        e
+    })?;
+    
+    println!("📁 Full file path: {:?}", full_path);
+    
+    // Ensure session directory exists
+    if let Some(parent) = full_path.parent() {
+        println!("📁 Creating directory: {:?}", parent);
+        std::fs::create_dir_all(parent)
+            .map_err(|e| {
+                println!("❌ Failed to create session directory: {}", e);
+                format!("Failed to create session directory: {}", e)
+            })?;
+    }
+    
+    // Create transcript line
+    let transcript_line = TranscriptLine {
+        t_ms,
+        speaker,
+        text,
+    };
+    
+    println!("📝 Created transcript line: {:?}", transcript_line);
+    
+    // Serialize to JSON and append to file
+    let json_line = serde_json::to_string(&transcript_line)
+        .map_err(|e| {
+            println!("❌ Failed to serialize transcript line: {}", e);
+            format!("Failed to serialize transcript line: {}", e)
+        })?;
+    
+    println!("📝 Serialized JSON: {}", json_line);
+    
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&full_path)
+        .map_err(|e| {
+            println!("❌ Failed to open transcript file {:?}: {}", full_path, e);
+            format!("Failed to open transcript file: {}", e)
+        })?;
+    
+    println!("📝 Opened file for writing");
+    
+    writeln!(file, "{}", json_line)
+        .map_err(|e| {
+            println!("❌ Failed to write to transcript file: {}", e);
+            format!("Failed to write to transcript file: {}", e)
+        })?;
+    
+    println!("✅ Successfully wrote transcript line to file");
+    Ok(())
+}
+
+#[tauri::command]
+async fn cmd_read_transcript(
+    id: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<TranscriptLine>, String> {
+    println!("🔧 cmd_read_transcript called with id: {}", id);
+    
+    let db = state.db.lock().map_err(|e| {
+        println!("❌ Failed to lock database: {}", e);
+        e.to_string()
+    })?;
+    
+    // Get session to ensure it exists and get transcript path
+    let session = db.get_session(&id).map_err(|e| e.to_string())?
+        .ok_or("Session not found")?;
+    
+    let transcript_path = session.transcript_path
+        .unwrap_or_else(|| "transcript.jsonl".to_string()); // Default if missing
+    
+    let full_path = get_session_file_path(&id, &transcript_path)?;
+    
+    // Check if file exists
+    if !full_path.exists() {
+        return Ok(Vec::new());
+    }
+    
+    let file = File::open(full_path)
+        .map_err(|e| format!("Failed to open transcript file: {}", e))?;
+    
+    let reader = BufReader::new(file);
+    let mut transcript_lines = Vec::new();
+    
+    for line in reader.lines() {
+        let line = line.map_err(|e| format!("Failed to read line: {}", e))?;
+        if !line.trim().is_empty() {
+            let transcript_line: TranscriptLine = serde_json::from_str(&line)
+                .map_err(|e| format!("Failed to parse transcript line: {}", e))?;
+            transcript_lines.push(transcript_line);
+        }
+    }
+    
+    Ok(transcript_lines)
+}
+
+#[tauri::command]
+async fn cmd_write_notes(
+    id: String,
+    markdown: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let db = state.db.lock().map_err(|e| e.to_string())?;
+    
+    // Get session to ensure it exists and get notes path
+    let session = db.get_session(&id).map_err(|e| e.to_string())?
+        .ok_or("Session not found")?;
+    
+    let notes_path = session.notes_path
+        .unwrap_or_else(|| "notes.md".to_string()); // Default if missing
+    
+    let full_path = get_session_file_path(&id, &notes_path)?;
+    
+    // Ensure session directory exists
+    if let Some(parent) = full_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create session directory: {}", e))?;
+    }
+    
+    // Write markdown content to file
+    std::fs::write(full_path, markdown)
+        .map_err(|e| format!("Failed to write notes file: {}", e))?;
+    
+    Ok(())
+}
+
+#[tauri::command]
+async fn cmd_read_notes(
+    id: String,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    let db = state.db.lock().map_err(|e| e.to_string())?;
+    
+    // Get session to ensure it exists and get notes path
+    let session = db.get_session(&id).map_err(|e| e.to_string())?
+        .ok_or("Session not found")?;
+    
+    let notes_path = session.notes_path
+        .unwrap_or_else(|| "notes.md".to_string()); // Default if missing
+    
+    let full_path = get_session_file_path(&id, &notes_path)?;
+    
+    // Check if file exists
+    if !full_path.exists() {
+        return Ok(String::new());
+    }
+    
+    // Read markdown content from file
+    std::fs::read_to_string(full_path)
+        .map_err(|e| format!("Failed to read notes file: {}", e))
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -84,9 +298,14 @@ pub fn run() {
         .manage(app_state)
         .invoke_handler(tauri::generate_handler![
             greet,
+            test_backend,
             cmd_list_sessions,
             cmd_create_session,
-            cmd_update_session_status
+            cmd_update_session_status,
+            cmd_append_transcript_line,
+            cmd_read_transcript,
+            cmd_write_notes,
+            cmd_read_notes
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -49,3 +49,10 @@ impl Default for SessionStatus {
         SessionStatus::Draft
     }
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TranscriptLine {
+    pub t_ms: u64,
+    pub speaker: String,
+    pub text: String,
+}

--- a/src/components/recorder/NotesHighlightsPane.tsx
+++ b/src/components/recorder/NotesHighlightsPane.tsx
@@ -1,15 +1,41 @@
-import { useState } from 'react';
-
-import { BookOpen, Star, Plus } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import { BookOpen, Star, Plus, Save } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 
 interface NotesHighlightsPaneProps {
   isRecording: boolean;
+  notes: string;
+  onNotesChange: (notes: string) => void;
+  onSaveNotes: () => void;
 }
 
-export default function NotesHighlightsPane({ isRecording }: NotesHighlightsPaneProps) {
+export default function NotesHighlightsPane({ 
+  isRecording, 
+  notes, 
+  onNotesChange, 
+  onSaveNotes 
+}: NotesHighlightsPaneProps) {
   const [activeTab, setActiveTab] = useState<'notes' | 'highlights'>('notes');
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  const [localNotes, setLocalNotes] = useState(notes);
+
+  // Update local notes when notes prop changes
+  useEffect(() => {
+    setLocalNotes(notes);
+    setHasUnsavedChanges(false);
+  }, [notes]);
+
+  const handleNotesChange = (value: string) => {
+    setLocalNotes(value);
+    onNotesChange(value);
+    setHasUnsavedChanges(true);
+  };
+
+  const handleSave = () => {
+    onSaveNotes();
+    setHasUnsavedChanges(false);
+  };
 
   const tabs = [
     { id: 'notes', label: 'Notes', icon: BookOpen },
@@ -49,31 +75,41 @@ export default function NotesHighlightsPane({ isRecording }: NotesHighlightsPane
       {/* Content */}
       <div className="flex-1 p-4">
         {activeTab === 'notes' ? (
-          <div className="space-y-4">
+          <div className="space-y-4 h-full flex flex-col">
             <div className="flex items-center justify-between">
               <h4 className="font-medium">Session Notes</h4>
               <Button
                 variant="outline"
                 size="sm"
-                disabled={!isRecording}
+                onClick={handleSave}
+                disabled={!hasUnsavedChanges}
                 className="flex items-center gap-2"
               >
-                <Plus className="w-4 h-4" />
-                Add Note
+                <Save className="w-4 h-4" />
+                Save
               </Button>
             </div>
             
-            <div className="space-y-3">
-              <Card>
-                <CardContent className="p-3">
-                  <p className="text-sm text-muted-foreground">
-                    {isRecording 
-                      ? "Click 'Add Note' to capture important points during the session"
-                      : "Start recording to add notes to your session"
-                    }
-                  </p>
-                </CardContent>
-              </Card>
+            <div className="flex-1 flex flex-col">
+              <textarea
+                value={localNotes}
+                onChange={(e) => handleNotesChange(e.target.value)}
+                placeholder="Start typing your notes here... Supports Markdown formatting."
+                className="flex-1 w-full p-3 text-sm border rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent bg-background"
+                style={{ minHeight: '300px' }}
+              />
+              
+              {hasUnsavedChanges && (
+                <p className="text-xs text-muted-foreground mt-2">
+                  You have unsaved changes
+                </p>
+              )}
+              
+              <div className="mt-3 text-xs text-muted-foreground">
+                <p>Tips: Use Markdown syntax for formatting</p>
+                <p>• **bold**, *italic*, `code`</p>
+                <p>• # Heading, - List items</p>
+              </div>
             </div>
           </div>
         ) : (

--- a/src/components/recorder/RecorderLayout.tsx
+++ b/src/components/recorder/RecorderLayout.tsx
@@ -6,13 +6,19 @@ import { TranscriptLineData } from './TranscriptLine';
 interface RecorderLayoutProps {
   transcriptLines: TranscriptLineData[];
   isRecording: boolean;
+  notes: string;
   onAddBookmark: () => void;
+  onNotesChange: (notes: string) => void;
+  onSaveNotes: () => void;
 }
 
 export default function RecorderLayout({
   transcriptLines,
   isRecording,
-  onAddBookmark
+  notes,
+  onAddBookmark,
+  onNotesChange,
+  onSaveNotes
 }: RecorderLayoutProps) {
   return (
     <motion.div
@@ -43,7 +49,12 @@ export default function RecorderLayout({
           transition={{ delay: 0.2 }}
           className="w-80 bg-card border rounded-lg shadow-sm overflow-hidden"
         >
-          <NotesHighlightsPane isRecording={isRecording} />
+          <NotesHighlightsPane 
+            isRecording={isRecording}
+            notes={notes}
+            onNotesChange={onNotesChange}
+            onSaveNotes={onSaveNotes}
+          />
         </motion.div>
       </div>
     </motion.div>

--- a/src/components/recorder/TranscriptLine.tsx
+++ b/src/components/recorder/TranscriptLine.tsx
@@ -1,12 +1,23 @@
 import { motion } from 'framer-motion';
 import { Clock, Bookmark } from 'lucide-react';
+import { TranscriptLine as BackendTranscriptLine } from '@/types/session';
 
 export interface TranscriptLineData {
   id: string;
   timestamp: number;
   text: string;
+  speaker?: string;
   isBookmarked?: boolean;
 }
+
+// Convert backend TranscriptLine to frontend TranscriptLineData
+export const convertTranscriptLine = (backendLine: BackendTranscriptLine, index: number): TranscriptLineData => ({
+  id: `line-${backendLine.t_ms}-${index}`,
+  timestamp: Math.floor(backendLine.t_ms / 1000), // Convert ms to seconds
+  text: backendLine.text,
+  speaker: backendLine.speaker,
+  isBookmarked: false,
+});
 
 interface TranscriptLineProps {
   line: TranscriptLineData;
@@ -34,6 +45,9 @@ export default function TranscriptLine({ line, isLatest = false }: TranscriptLin
       </div>
       
       <div className="flex-1">
+        {line.speaker && (
+          <p className="text-xs font-medium text-muted-foreground mb-1">{line.speaker}:</p>
+        )}
         <p className="text-sm leading-relaxed">{line.text}</p>
       </div>
       

--- a/src/components/recorder/index.ts
+++ b/src/components/recorder/index.ts
@@ -6,3 +6,4 @@ export { default as TranscriptLine } from './TranscriptLine';
 export { default as CatchUpSummaryModal } from './CatchUpSummaryModal';
 
 export type { TranscriptLineData } from './TranscriptLine';
+export { convertTranscriptLine } from './TranscriptLine';

--- a/src/lib/sessions.ts
+++ b/src/lib/sessions.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import { Session, CreateSessionRequest, UpdateSessionStatusRequest } from '@/types/session';
+import { Session, CreateSessionRequest, UpdateSessionStatusRequest, TranscriptLine } from '@/types/session';
 
 export const sessionsClient = {
   async listSessions(): Promise<Session[]> {
@@ -12,5 +12,43 @@ export const sessionsClient = {
 
   async updateSessionStatus(request: UpdateSessionStatusRequest): Promise<void> {
     await invoke('cmd_update_session_status', { ...request });
+  },
+
+  // Transcript operations
+  async appendTranscriptLine(id: string, t_ms: number, speaker: string, text: string): Promise<void> {
+    try {
+      await invoke('cmd_append_transcript_line', { id, tMs: t_ms, speaker, text });
+    } catch (error) {
+      console.error('Failed to save transcript line:', error);
+      
+      // Fallback to localStorage for development
+      const key = `transcript_${id}`;
+      const existing = JSON.parse(localStorage.getItem(key) || '[]');
+      existing.push({ t_ms, speaker, text });
+      localStorage.setItem(key, JSON.stringify(existing));
+    }
+  },
+
+  async readTranscript(id: string): Promise<TranscriptLine[]> {
+    try {
+      const result = await invoke<TranscriptLine[]>('cmd_read_transcript', { id });
+      return result;
+    } catch (error) {
+      console.error('Failed to read transcript:', error);
+      
+      // Fallback to localStorage for development
+      const key = `transcript_${id}`;
+      const existing = JSON.parse(localStorage.getItem(key) || '[]');
+      return existing;
+    }
+  },
+
+  // Notes operations
+  async writeNotes(id: string, markdown: string): Promise<void> {
+    await invoke('cmd_write_notes', { id, markdown });
+  },
+
+  async readNotes(id: string): Promise<string> {
+    return await invoke<string>('cmd_read_notes', { id });
   }
 };

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -21,3 +21,9 @@ export interface UpdateSessionStatusRequest {
   id: string;
   status: SessionStatus;
 }
+
+export interface TranscriptLine {
+  t_ms: number;
+  speaker: string;
+  text: string;
+}


### PR DESCRIPTION


- Add session-specific directory structure at ~/.polka/data/sessions/<id>/
- Store transcripts as JSONL and notes as Markdown files per session
- Create Tauri commands for transcript and notes persistence:
  * cmd_append_transcript_line: append transcript lines to .jsonl file
  * cmd_read_transcript: load existing transcript lines from file
  * cmd_write_notes/cmd_read_notes: save/load session notes as .md files
- Update session creation to pre-allocate folders and set file paths
- Implement real-time transcript persistence during recording
- Add notes editing with Markdown textarea and auto-save functionality
- Fix parameter mapping between frontend camelCase and Rust snake_case
- Ensure transcript timestamps continue from last recorded line on resume
- Add comprehensive error handling and localStorage fallback for development

Sessions now fully persist across app restarts with organized file storage.