### PR TITLE
feat: implement clean font sizing with execCommand

### DIFF
--- a/src/components/features/common/RichTextEditor.tsx
+++ b/src/components/features/common/RichTextEditor.tsx
@@ -31,16 +31,27 @@ const RichTextEditor = forwardRef<HTMLDivElement, RichTextEditorProps>(({
   const handleInput = useCallback(() => {
     if (editorRef.current) {
       // Clean up empty formatting spans that only contain zero-width spaces
+      // But only if they're not at the current cursor position
+      const selection = window.getSelection();
+      const currentRange = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+      
       const spans = editorRef.current.querySelectorAll('span[data-polka-format]');
       spans.forEach(span => {
         if (span.textContent === '\u200B' || span.textContent === '') {
-          // If span only contains zero-width space or is empty, remove it
-          const parent = span.parentNode;
-          if (parent) {
-            while (span.firstChild) {
-              parent.insertBefore(span.firstChild, span);
+          // Don't remove the span if the cursor is currently inside it
+          const isCursorInside = currentRange && 
+            span.contains(currentRange.startContainer) && 
+            span.contains(currentRange.endContainer);
+          
+          if (!isCursorInside) {
+            // If span only contains zero-width space or is empty, remove it
+            const parent = span.parentNode;
+            if (parent) {
+              while (span.firstChild) {
+                parent.insertBefore(span.firstChild, span);
+              }
+              parent.removeChild(span);
             }
-            parent.removeChild(span);
           }
         }
       });

--- a/src/contexts/FormattingContext.tsx
+++ b/src/contexts/FormattingContext.tsx
@@ -22,7 +22,7 @@ const defaultFormatting: FormattingState = {
   bold: false,
   italic: false,
   underline: false,
-  fontSize: '16px',
+  fontSize: '3',
   fontFamily: 'Arial, sans-serif',
   textColor: '#000000',
   highlightColor: 'transparent',


### PR DESCRIPTION
- Replace complex DOM manipulation with simple execCommand approach
- Use execCommand sizes (1-7) instead of pixel values for consistency
- Add Google Docs-style −/+ buttons for font size adjustment
- Fix initial font size display to show '3' instead of '16px'
- Remove complex line height normalization and span creation logic
- Prevent selection loss with onPointerDown event handlers
- Simplify font family changes to use execCommand('fontName')
- Update color/highlight functions to use proper text node structure
- Remove unused helper functions and complex state management
- Ensure consistent UI behavior across all font controls

This provides a much cleaner, more reliable font sizing experience that works consistently without side effects during text editing.